### PR TITLE
[#185177032] Prüfe ob Postfix Relay Werte enthält 

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,9 @@
     mode: 0644
 
 - name: Configure Postfix _sasl
-  when: _sasl is defined
+  when:
+    - _sasl is defined and _sasl | length
+    - _postfix.relay is defined and _postfix.relay | length
   tags:
     - molecule-idempotence-notest
   block:
@@ -71,17 +73,20 @@
         owner: root
         group: root
 
-    - name: Create transport_maps file
-      ansible.builtin.template:
-        src: etc/postfix/transport_maps.j2
-        dest: /etc/postfix/transport_maps
-        mode: 0644
-        owner: root
-        group: root
-
     - name: Add taggingsmtp transport to master.cf
       ansible.builtin.lineinfile:
         path: /etc/postfix/master.cf
         regexp: '^taggingsmtp'
         insertafter: '^smtp.*unix.*smtp$'
         line: 'taggingsmtp      unix  -       -       -       -       -       smtp -o smtp_header_checks=regexp:/etc/postfix/header_checks'
+
+- name: Create transport_maps file
+  when:
+    - _postfix.tagging_transport is defined
+    - _postfix.relay is defined and _postfix.relay | length
+  ansible.builtin.template:
+    src: etc/postfix/transport_maps.j2
+    dest: /etc/postfix/transport_maps
+    mode: 0644
+    owner: root
+    group: root

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -22,13 +22,13 @@ myhostname = {{ ansible_hostname }}.{{ _postfix.domain }}
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
 myorigin = /etc/mailname
-{% if _postfix.relay is defined %}
+{% if _postfix.relay is defined and _postfix.relay | length  %}
 relayhost = [{{ _postfix.relay.host }}]:{{ _postfix.relay.port }}
 {% endif %}
 {% if _postfix.tagging_transport is defined %}
 transport_maps = regexp:/etc/postfix/transport_maps
 {% endif %}
-{% if _sasl is defined %}
+{% if _sasl is defined and _sasl | length %}
 smtp_sasl_auth_enable = yes
 smtp_sasl_security_options = noanonymous
 smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd


### PR DESCRIPTION
- normalerweise sind alle 3 Werte gesetzt (`_sasl`, `_postfix.relay` und `_postfix.tagging_transport`)
- jetzt haben wir das Scenario in dem wir `_postfix.tagging_transport` haben, aber die anderen Werte nicht

Die Änderungen stellen sicher, dass die im Template verwendeten Variablen geprüft werden (z.B. `_postfix.relay` wird in der sasl config genutzt). Des weiteren überprüfen wir ob die werte `| length` (nicht leer) sind, damit man als Benutzer der Rolle einfacher nutzen kann)